### PR TITLE
Modernisation for Laravel 13+ and PHP 8.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Eloquent Sluggable
 
-[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-sluggable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
-[![Total Downloads](https://poser.pugx.org/kduma/eloquent-sluggable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
-[![License](https://poser.pugx.org/kduma/eloquent-sluggable/license.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
+Eloquent trait for automatically generating unique slugs for Laravel models.
 
-Eases using and generating slugs for Laravel Eloquent models.
-
-Check full documentation here: [opensource.duma.sh/libraries/php/eloquent-sluggable](https://opensource.duma.sh/libraries/php/eloquent-sluggable)
+Full documentation: [opensource.duma.sh/libraries/php/eloquent-sluggable](https://opensource.duma.sh/libraries/php/eloquent-sluggable)
 
 ## Requirements
 
@@ -19,86 +15,23 @@ Check full documentation here: [opensource.duma.sh/libraries/php/eloquent-slugga
 composer require kduma/eloquent-sluggable
 ```
 
-## Setup
-
-Add the `Sluggable` trait to your model:
-
-```php
-use KDuma\Eloquent\Sluggable;
-
-class Post extends Model
-{
-    use Sluggable;
-}
-```
-
-In your migration, create a `slug` column:
-
-```php
-$table->string('slug')->unique();
-```
-
-## Configuration
-
-### New style — PHP Attribute (recommended)
+## Usage
 
 ```php
 use KDuma\Eloquent\Sluggable;
 use KDuma\Eloquent\Attributes\HasSlug;
 
-#[HasSlug(from: 'name', field: 'slug')]
-class Product extends Model
-{
-    use Sluggable;
-}
-```
-
-### Old style — model properties (deprecated, triggers `E_USER_DEPRECATED`)
-
-```php
+#[HasSlug(from: 'title', field: 'slug')]
 class Post extends Model
 {
     use Sluggable;
-
-    protected string $sluggable_from = 'name';  // field to generate slug from (default: 'title')
-    protected string $slug_field = 'slug';       // slug column name (default: 'slug')
 }
 ```
 
-### Default behaviour (no configuration)
-
-Without any configuration, the trait reads from the `title` field and stores the slug in the `slug` column.
+Add a `slug` column to your migration:
 
 ```php
-class Post extends Model
-{
-    use Sluggable; // uses $post->title → stores in $post->slug
-}
+$table->string('slug')->unique();
 ```
 
-## Usage
-
-- Slug is automatically generated on `create` and regenerated on `update` if the slug field is empty.
-- `$model->generateSlug()` — manually trigger slug generation (remember to `save()` afterwards)
-- `Model::whereSlug($slug)` — query scope to find by slug
-- `$model->getSlugField()` — returns the configured slug field name
-
-### Custom slug source
-
-Override `SluggableString()` on your model for full control:
-
-```php
-class Post extends Model
-{
-    use Sluggable;
-
-    protected function SluggableString(): string
-    {
-        return $this->year . ' ' . $this->title;
-    }
-}
-```
-
-## Packagist
-
-[kduma/eloquent-sluggable](https://packagist.org/packages/kduma/eloquent-sluggable)
+Slug is auto-generated on create. Find by slug with `Post::whereSlug($slug)`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Eloquent Sluggable
 
+[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-sluggable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
+[![Total Downloads](https://poser.pugx.org/kduma/eloquent-sluggable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
+[![License](https://poser.pugx.org/kduma/eloquent-sluggable/license.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
+
 Eloquent trait for automatically generating unique slugs for Laravel models.
 
 Full documentation: [opensource.duma.sh/libraries/php/eloquent-sluggable](https://opensource.duma.sh/libraries/php/eloquent-sluggable)

--- a/README.md
+++ b/README.md
@@ -1,47 +1,104 @@
-# L5-eloquent-sluggable
-[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-sluggable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-sluggable) 
-[![Total Downloads](https://poser.pugx.org/kduma/eloquent-sluggable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-sluggable) 
-[![Latest Unstable Version](https://poser.pugx.org/kduma/eloquent-sluggable/v/unstable.svg)](https://packagist.org/packages/kduma/eloquent-sluggable) 
+# Eloquent Sluggable
+
+[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-sluggable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
+[![Total Downloads](https://poser.pugx.org/kduma/eloquent-sluggable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
 [![License](https://poser.pugx.org/kduma/eloquent-sluggable/license.svg)](https://packagist.org/packages/kduma/eloquent-sluggable)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/5cc51ad6-606c-43d5-bb3b-6f0bbde61dd0/mini.png)](https://insight.sensiolabs.com/projects/5cc51ad6-606c-43d5-bb3b-6f0bbde61dd0)
-[![StyleCI](https://styleci.io/repos/30116299/shield?branch=master)](https://styleci.io/repos/30116299)
-[![Build Status](https://travis-ci.org/kduma/L5-eloquent-sluggable.svg?branch=master)](https://travis-ci.org/kduma/L5-eloquent-sluggable)
 
-
-Eases using and generating slugs Laravel Eloquent models.
+Eases using and generating slugs for Laravel Eloquent models.
 
 Check full documentation here: [opensource.duma.sh/libraries/php/eloquent-sluggable](https://opensource.duma.sh/libraries/php/eloquent-sluggable)
 
-# Setup
-Add the package to the require section of your composer.json and run `composer update`
+## Requirements
 
-    "kduma/eloquent-sluggable": "^1.1"
+- PHP `^8.3`
+- Laravel `^13.0`
 
-# Prepare models
-Inside your model (not on top of file) add following lines:
-    
-    use \KDuma\Eloquent\Slugabble;
+## Installation
 
-Optionally you can add also `SluggableString` function which will return string from which slug will be made (default it uses `title` field):
+```bash
+composer require kduma/eloquent-sluggable
+```
 
-    protected function SluggableString(){
-        return $this->year.' '.$this->title;
-    }  
+## Setup
 
-In database create `slug` string field. If you use migrations, you can use following snippet:
+Add the `Sluggable` trait to your model:
 
-    $table->string('slug')->unique();
+```php
+use KDuma\Eloquent\Sluggable;
 
-# Usage
-By default it generates slug on first save.
+class Post extends Model
+{
+    use Sluggable;
+}
+```
 
-- `$model->newSlug()` - Generate new slug. (Remember to save it by yourself)
-- `Model::whereSlug($slug)->first()` - Find by slug. (`whereSlug` is query scope)
-   
+In your migration, create a `slug` column:
 
-# Eric L. Barnes
+```php
+$table->string('slug')->unique();
+```
 
-A special thanks to [Eric L. Barnes](https://dotdev.co/creating-unique-title-slugs-with-laravel/), an original code creator that this package is based on.
+## Configuration
 
-# Packagist
-View this package on Packagist.org: [kduma/eloquent-sluggable](https://packagist.org/packages/kduma/eloquent-sluggable)
+### New style — PHP Attribute (recommended)
+
+```php
+use KDuma\Eloquent\Sluggable;
+use KDuma\Eloquent\Attributes\HasSlug;
+
+#[HasSlug(from: 'name', field: 'slug')]
+class Product extends Model
+{
+    use Sluggable;
+}
+```
+
+### Old style — model properties (deprecated, triggers `E_USER_DEPRECATED`)
+
+```php
+class Post extends Model
+{
+    use Sluggable;
+
+    protected string $sluggable_from = 'name';  // field to generate slug from (default: 'title')
+    protected string $slug_field = 'slug';       // slug column name (default: 'slug')
+}
+```
+
+### Default behaviour (no configuration)
+
+Without any configuration, the trait reads from the `title` field and stores the slug in the `slug` column.
+
+```php
+class Post extends Model
+{
+    use Sluggable; // uses $post->title → stores in $post->slug
+}
+```
+
+## Usage
+
+- Slug is automatically generated on `create` and regenerated on `update` if the slug field is empty.
+- `$model->generateSlug()` — manually trigger slug generation (remember to `save()` afterwards)
+- `Model::whereSlug($slug)` — query scope to find by slug
+- `$model->getSlugField()` — returns the configured slug field name
+
+### Custom slug source
+
+Override `SluggableString()` on your model for full control:
+
+```php
+class Post extends Model
+{
+    use Sluggable;
+
+    protected function SluggableString(): string
+    {
+        return $this->year . ' ' . $this->title;
+    }
+}
+```
+
+## Packagist
+
+[kduma/eloquent-sluggable](https://packagist.org/packages/kduma/eloquent-sluggable)

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
-    "illuminate/support": "7.*|8.*|9.*|10.*|11.*|12.*|13.*"
+    "php": "^8.3",
+    "illuminate/support": "^13.0",
+    "illuminate/database": "^13.0"
   },
   "autoload": {
     "psr-4": {
@@ -26,7 +27,7 @@
     }
   },
   "require-dev": {
-    "mockery/mockery": "0.9.*",
-    "phpunit/phpunit": "^5.5"
+    "phpunit/phpunit": "^11.0",
+    "mockery/mockery": "^1.6"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,58 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        colors="true"
-        processIsolation="false"
-        stopOnFailure="false"
-        syntaxCheck="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         colors="true"
+         stopOnFailure="false"
 >
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
     </php>
 
-    <!-- Add any additional test suites you want to run here -->
     <testsuites>
         <testsuite name="app">
             <directory>./tests</directory>
         </testsuite>
-        <testsuite name="receipt">
-            <directory>./tests</directory>
-            <exclude>./tests/ReceiptItems.php</exclude>
-        </testsuite>
     </testsuites>
 
-    <filter>
-        <!--
-        <blacklist>
-            <directory suffix=".php">/path/to/files</directory>
-            <file>/path/to/file</file>
-            <exclude>
-                <directory suffix=".php">/path/to/files</directory>
-                <file>/path/to/file</file>
-            </exclude>
-        </blacklist>
-        -->
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">./src</directory>
-            <!--
-            <file>/path/to/file</file>
-            <exclude>
-                <directory suffix=".php">/path/to/files</directory>
-                <file>/path/to/file</file>
-            </exclude>
-            -->
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log
-                type="coverage-html"
-                target="./tmp/coverage/html/"
-                charset="UTF-8"
-                highlight="true"
-                lowUpperBound="60"
-                highLowerBound="90"
-        />
-    </logging>
-
+        </include>
+    </source>
 </phpunit>

--- a/src/Attributes/HasSlug.php
+++ b/src/Attributes/HasSlug.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace KDuma\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class HasSlug
+{
+    public function __construct(
+        public readonly string $from = 'title',
+        public readonly string $field = 'slug',
+    ) {}
+}

--- a/src/Slugabble.php
+++ b/src/Slugabble.php
@@ -1,108 +1,12 @@
 <?php
+declare(strict_types=1);
 
 namespace KDuma\Eloquent;
 
-use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\Model;
-
 /**
- * Class Slugabble.
+ * @deprecated Use Sluggable instead. This is a backwards-compatibility alias.
  */
 trait Slugabble
 {
-    /**
-     * Boot the trait.
-     *
-     * @codeCoverageIgnore Eloquent specific code
-     */
-    protected static function bootSlugabble()
-    {
-        static::creating(function (Model $model) {
-            if ($model->slug == '') {
-                $model->generateSlug();
-            }
-        });
-        static::updating(function (Model $model) {
-            if ($model->slug == '') {
-                $model->generateSlug();
-            }
-        });
-    }
-
-    /**
-     * @return mixed
-     */
-    protected function getSluggableString()
-    {
-        if (method_exists($this, 'SluggableString')) {
-            return $this->SluggableString();
-        }
-
-        return $this->title;
-    }
-
-    /**
-     * @param $title
-     * @return string
-     * @throws \Exception
-     */
-    protected function findSlug($title)
-    {
-        // Normalize the title
-        $slug = Str::slug($title);
-
-        // Get any that could possibly be related.
-        // This cuts the queries down by doing it once.
-        $existingSlugs = $this->getExistingSlugs($slug);
-
-        // If we haven't used it before then we are all good.
-        if (! $existingSlugs->contains('slug', $slug)) {
-            return $slug;
-        }
-
-        // Just append numbers like a savage until we find not used.
-        for ($i = 1; $i <= 100; $i++) {
-            $newSlug = $slug.'-'.$i;
-            if (! $existingSlugs->contains('slug', $newSlug)) {
-                return $newSlug;
-            }
-        }
-
-        throw new \Exception('Can not create a unique slug');
-    }
-
-    /**
-     * Generates slug.
-     */
-    public function generateSlug()
-    {
-        $this->slug = $this->findSlug($this->getSluggableString());
-    }
-
-    /**
-     * @param $query
-     * @param $slug
-     * @return bool|int
-     *
-     * @codeCoverageIgnore Eloquent specific code
-     */
-    public function scopeWhereSlug($query, $slug)
-    {
-        return $query->where('slug', $slug);
-    }
-
-    /**
-     * @param $slug
-     * @return mixed
-     *
-     * @codeCoverageIgnore Eloquent specific code
-     */
-    public function getExistingSlugs($slug)
-    {
-        return self::select('slug')->where('slug', 'like', $slug.'%')
-            ->when($this->id, function ($query) {
-                return $query->where('id', '<>', $this->id);
-            })
-            ->get();
-    }
+    use Sluggable;
 }

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -40,7 +40,7 @@ trait Sluggable
 
         $from = $this->resolveSluggableConfig('from', 'sluggable_from', 'title');
 
-        return $this->{$from};
+        return (string) $this->{$from};
     }
 
     protected function findSlug(string $title): string
@@ -59,7 +59,7 @@ trait Sluggable
             }
         }
 
-        throw new \RuntimeException('Can not create a unique slug');
+        throw new \RuntimeException('Cannot create a unique slug after 100 attempts');
     }
 
     public function generateSlug(): void

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -90,13 +90,13 @@ trait Sluggable
             return $value;
         }
 
-        if (isset($this->{$legacyProperty})) {
+        if (property_exists($this, $legacyProperty)) {
             trigger_error(
                 "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasSlug] attribute instead.',
                 E_USER_DEPRECATED,
             );
 
-            return $this->{$legacyProperty};
+            return $this->{$legacyProperty} ?? $default;
         }
 
         return $default;

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -1,108 +1,104 @@
 <?php
+declare(strict_types=1);
 
 namespace KDuma\Eloquent;
 
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use KDuma\Eloquent\Attributes\HasSlug;
 
-/**
- * Class Sluggable.
- */
 trait Sluggable
 {
-    /**
-     * Boot the trait.
-     *
-     * @codeCoverageIgnore Eloquent specific code
-     */
-    protected static function bootSluggable()
+    protected static function bootSluggable(): void
     {
-        static::creating(function (Model $model) {
-            if ($model->slug == '') {
+        static::creating(function (Model $model): void {
+            $field = $model->getSlugField();
+            if ($model->{$field} === '' || $model->{$field} === null) {
                 $model->generateSlug();
             }
         });
-        static::updating(function (Model $model) {
-            if ($model->slug == '') {
+        static::updating(function (Model $model): void {
+            $field = $model->getSlugField();
+            if ($model->{$field} === '' || $model->{$field} === null) {
                 $model->generateSlug();
             }
         });
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getSluggableString()
+    public function getSlugField(): string
+    {
+        return $this->resolveSluggableConfig('field', 'slug_field', 'slug');
+    }
+
+    protected function getSluggableString(): string
     {
         if (method_exists($this, 'SluggableString')) {
             return $this->SluggableString();
         }
 
-        return $this->title;
+        $from = $this->resolveSluggableConfig('from', 'sluggable_from', 'title');
+
+        return $this->{$from};
     }
 
-    /**
-     * @param $title
-     * @return string
-     * @throws \Exception
-     */
-    protected function findSlug($title)
+    protected function findSlug(string $title): string
     {
-        // Normalize the title
         $slug = Str::slug($title);
-
-        // Get any that could possibly be related.
-        // This cuts the queries down by doing it once.
         $existingSlugs = $this->getExistingSlugs($slug);
 
-        // If we haven't used it before then we are all good.
-        if (! $existingSlugs->contains('slug', $slug)) {
+        if (!$existingSlugs->contains($this->getSlugField(), $slug)) {
             return $slug;
         }
 
-        // Just append numbers like a savage until we find not used.
         for ($i = 1; $i <= 100; $i++) {
-            $newSlug = $slug.'-'.$i;
-            if (! $existingSlugs->contains('slug', $newSlug)) {
+            $newSlug = $slug . '-' . $i;
+            if (!$existingSlugs->contains($this->getSlugField(), $newSlug)) {
                 return $newSlug;
             }
         }
 
-        throw new \Exception('Can not create a unique slug');
+        throw new \RuntimeException('Can not create a unique slug');
     }
 
-    /**
-     * Generates slug.
-     */
-    public function generateSlug()
+    public function generateSlug(): void
     {
-        $this->slug = $this->findSlug($this->getSluggableString());
+        $this->{$this->getSlugField()} = $this->findSlug($this->getSluggableString());
     }
 
-    /**
-     * @param $query
-     * @param $slug
-     * @return bool|int
-     *
-     * @codeCoverageIgnore Eloquent specific code
-     */
-    public function scopeWhereSlug($query, $slug)
+    public function scopeWhereSlug(Builder $query, string $slug): Builder
     {
-        return $query->where('slug', $slug);
+        return $query->where($this->getSlugField(), $slug);
     }
 
-    /**
-     * @param $slug
-     * @return mixed
-     *
-     * @codeCoverageIgnore Eloquent specific code
-     */
-    public function getExistingSlugs($slug)
+    public function getExistingSlugs(string $slug): Collection
     {
-        return self::select('slug')->where('slug', 'like', $slug.'%')
-            ->when($this->id, function ($query) {
+        $field = $this->getSlugField();
+
+        return static::select($field)->where($field, 'like', $slug . '%')
+            ->when($this->id, function (Builder $query): Builder {
                 return $query->where('id', '<>', $this->id);
             })
             ->get();
+    }
+
+    private function resolveSluggableConfig(string $attrProperty, string $legacyProperty, mixed $default): mixed
+    {
+        $value = static::resolveClassAttribute(HasSlug::class, $attrProperty);
+        if ($value !== null) {
+            return $value;
+        }
+
+        if (isset($this->{$legacyProperty})) {
+            trigger_error(
+                "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasSlug] attribute instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return $this->{$legacyProperty};
+        }
+
+        return $default;
     }
 }

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -91,10 +91,15 @@ trait Sluggable
         }
 
         if (property_exists($this, $legacyProperty)) {
-            trigger_error(
-                "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasSlug] attribute instead.',
-                E_USER_DEPRECATED,
-            );
+            static $fired = [];
+            $key = static::class . '::$' . $legacyProperty;
+            if (!isset($fired[$key])) {
+                $fired[$key] = true;
+                trigger_error(
+                    "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasSlug] attribute instead.',
+                    E_USER_DEPRECATED,
+                );
+            }
 
             return $this->{$legacyProperty} ?? $default;
         }

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace KDuma\Eloquent;
+
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class Sluggable.
+ */
+trait Sluggable
+{
+    /**
+     * Boot the trait.
+     *
+     * @codeCoverageIgnore Eloquent specific code
+     */
+    protected static function bootSluggable()
+    {
+        static::creating(function (Model $model) {
+            if ($model->slug == '') {
+                $model->generateSlug();
+            }
+        });
+        static::updating(function (Model $model) {
+            if ($model->slug == '') {
+                $model->generateSlug();
+            }
+        });
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getSluggableString()
+    {
+        if (method_exists($this, 'SluggableString')) {
+            return $this->SluggableString();
+        }
+
+        return $this->title;
+    }
+
+    /**
+     * @param $title
+     * @return string
+     * @throws \Exception
+     */
+    protected function findSlug($title)
+    {
+        // Normalize the title
+        $slug = Str::slug($title);
+
+        // Get any that could possibly be related.
+        // This cuts the queries down by doing it once.
+        $existingSlugs = $this->getExistingSlugs($slug);
+
+        // If we haven't used it before then we are all good.
+        if (! $existingSlugs->contains('slug', $slug)) {
+            return $slug;
+        }
+
+        // Just append numbers like a savage until we find not used.
+        for ($i = 1; $i <= 100; $i++) {
+            $newSlug = $slug.'-'.$i;
+            if (! $existingSlugs->contains('slug', $newSlug)) {
+                return $newSlug;
+            }
+        }
+
+        throw new \Exception('Can not create a unique slug');
+    }
+
+    /**
+     * Generates slug.
+     */
+    public function generateSlug()
+    {
+        $this->slug = $this->findSlug($this->getSluggableString());
+    }
+
+    /**
+     * @param $query
+     * @param $slug
+     * @return bool|int
+     *
+     * @codeCoverageIgnore Eloquent specific code
+     */
+    public function scopeWhereSlug($query, $slug)
+    {
+        return $query->where('slug', $slug);
+    }
+
+    /**
+     * @param $slug
+     * @return mixed
+     *
+     * @codeCoverageIgnore Eloquent specific code
+     */
+    public function getExistingSlugs($slug)
+    {
+        return self::select('slug')->where('slug', 'like', $slug.'%')
+            ->when($this->id, function ($query) {
+                return $query->where('id', '<>', $this->id);
+            })
+            ->get();
+    }
+}

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -1,38 +1,41 @@
 <?php
 
-class SluggableTest extends PHPUnit_Framework_TestCase
+declare(strict_types=1);
+
+use KDuma\Eloquent\Sluggable;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class SluggableTest extends TestCase
 {
-    public function tearDown()
-    {
-        Mockery::close();
-    }
+    use MockeryPHPUnitIntegration;
 
-    /**
-     * @test
-     * @dataProvider provideExistingSlugs
-     */
-    public function test_slug_generation($ExpectedSlug, $ExistingSlugs)
+    #[Test]
+    #[DataProvider('provideExistingSlugs')]
+    public function test_slug_generation(string|false $expectedSlug, \Illuminate\Support\Collection $existingSlugs): void
     {
-        $TestModel = Mockery::mock('TestModel[getExistingSlugs]', [2017, 'Lorem ipsum dolor sit ament...']);
+        $testModel = Mockery::mock('TestModel[getExistingSlugs]', [2017, 'Lorem ipsum dolor sit ament...']);
 
-        $TestModel->shouldReceive('getExistingSlugs')
+        $testModel->shouldReceive('getExistingSlugs')
             ->once()
             ->withArgs(['2017-lorem-ipsum-dolor-sit-ament'])
-            ->andReturn($ExistingSlugs);
+            ->andReturn($existingSlugs);
 
-        if (! $ExpectedSlug) {
-            $this->expectException('Exception');
-            $this->expectExceptionMessage('Can not create a unique slug');
+        if ($expectedSlug === false) {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Cannot create a unique slug after 100 attempts');
         }
 
-        $TestModel->generateSlug();
+        $testModel->generateSlug();
 
-        if ($ExpectedSlug) {
-            $this->assertEquals($ExpectedSlug, $TestModel->slug);
+        if ($expectedSlug !== false) {
+            $this->assertEquals($expectedSlug, $testModel->slug);
         }
     }
 
-    public function provideExistingSlugs()
+    public static function provideExistingSlugs(): array
     {
         return [
             'empty' => ['2017-lorem-ipsum-dolor-sit-ament', collect()],
@@ -46,99 +49,56 @@ class SluggableTest extends PHPUnit_Framework_TestCase
                 ['slug' => '2017-lorem-ipsum-dolor-sit-ament-1'],
             ])],
 
-            'fifthy-duplicates' => ['2017-lorem-ipsum-dolor-sit-ament-51', collect(range(0, 50))->map(function ($num) {
-                return ['slug' => '2017-lorem-ipsum-dolor-sit-ament'.($num ? '-'.$num : '')];
+            'fifty-duplicates' => ['2017-lorem-ipsum-dolor-sit-ament-51', collect(range(0, 50))->map(function (int $num): array {
+                return ['slug' => '2017-lorem-ipsum-dolor-sit-ament' . ($num ? '-' . $num : '')];
             })],
 
-            'hundread-duplicates' => [false, collect(range(0, 100))->map(function ($num) {
-                return ['slug' => '2017-lorem-ipsum-dolor-sit-ament'.($num ? '-'.$num : '')];
+            'hundred-duplicates' => [false, collect(range(0, 100))->map(function (int $num): array {
+                return ['slug' => '2017-lorem-ipsum-dolor-sit-ament' . ($num ? '-' . $num : '')];
             })],
         ];
     }
 
-    /**
-     * @test
-     */
-    public function test_slug_generation_without_custom_slug_generator()
+    #[Test]
+    public function test_slug_generation_without_custom_slug_generator(): void
     {
-        $TestModel = Mockery::mock('TestModelWithoutCustomSlugGenerator[getExistingSlugs]', ['Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et...']);
+        $testModel = Mockery::mock('TestModelWithoutCustomSlugGenerator[getExistingSlugs]', ['Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et...']);
 
-        $TestModel->shouldReceive('getExistingSlugs')
+        $testModel->shouldReceive('getExistingSlugs')
             ->once()
             ->withArgs(['lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-donec-et'])
             ->andReturn(collect());
 
-        $TestModel->generateSlug();
+        $testModel->generateSlug();
 
-        $this->assertEquals('lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-donec-et', $TestModel->slug);
+        $this->assertEquals('lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-donec-et', $testModel->slug);
     }
 }
 
-/**
- * Class TestModel.
- */
 class TestModel
 {
-    use \KDuma\Eloquent\Slugabble;
+    use Sluggable;
 
-    /**
-     * @var int
-     */
-    public $year;
+    public string $slug = '';
 
-    /**
-     * @var string
-     */
-    public $title;
+    public function __construct(
+        public int $year,
+        public string $title,
+    ) {}
 
-    /**
-     * @var string
-     */
-    public $slug;
-
-    /**
-     * TestModel constructor.
-     * @param int $year
-     * @param string $title
-     */
-    public function __construct($year, $title)
+    protected function SluggableString(): string
     {
-        $this->year = $year;
-        $this->title = $title;
-    }
-
-    /**
-     * @return string
-     */
-    protected function SluggableString()
-    {
-        return $this->year.' '.$this->title;
+        return $this->year . ' ' . $this->title;
     }
 }
 
-/**
- * Class TestModelWithoutCustomSlugGenerator.
- */
 class TestModelWithoutCustomSlugGenerator
 {
-    use \KDuma\Eloquent\Slugabble;
+    use Sluggable;
 
-    /**
-     * @var string
-     */
-    public $title;
+    public string $slug = '';
 
-    /**
-     * @var string
-     */
-    public $slug;
-
-    /**
-     * TestModelWithoutCustomSlugGenerator constructor.
-     * @param string $title
-     */
-    public function __construct($title)
-    {
-        $this->title = $title;
-    }
+    public function __construct(
+        public string $title,
+    ) {}
 }


### PR DESCRIPTION
## Summary
- Bump PHP requirement to `^8.3`, Laravel to `^13.0`
- Fix typo: rename `Slugabble` → `Sluggable` (with backward-compat alias)
- Add `HasSlug` PHP Attribute class for declarative configuration
- Add `declare(strict_types=1)` and full type hints
- Legacy `$slug_field` / `$sluggable_from` properties still work with `E_USER_DEPRECATED` notice